### PR TITLE
Local testing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,14 @@
 
 uqcsbot is a chat bot built in python for use on our [UQCS Slack Team](uqcs.slack.com).
 
-## Setting up the development environment
+## Setting up the local development environment
+
+To run the local development environment, make sure you have Python 3 installed.
+
+1. Run `python setup.py install`
+2. Run `python -m uqcsbot --dev`
+
+## Setting up the remote development environment
 
 To set everything up make sure you have Python 3, virtualenv, and [ngrok](https://ngrok.com/)
 
@@ -18,7 +25,7 @@ To set everything up make sure you have Python 3, virtualenv, and [ngrok](https:
 1. Run `python -m uqcsbot`
 1. Run `ngrok http 5000`
 1. Copy the https URL (It should look like `https://h7465j.ngrok.io`)
-1. Under Event Subscriptions, make sure events are enabled and paste this URL +  `/uqcsbot/events/` into the Request URL. (For example `https://h7465j.ngrok.io/uqcsbot/events`)
+1. Under Event Subscriptions, make sure events are enabled and paste this URL +  `/uqcsbot/events` into the Request URL. (For example `https://h7465j.ngrok.io/uqcsbot/events`)
 1. Subscribe to `message.channels` under bot events
 
 The bot should now be receiving all slack events. Because of how ngrok works, you will need to update the `ngrok` URL each time you run it unless you get a paid plan or deploy to an actual server instead of using `ngrok`.

--- a/uqcsbot/__init__.py
+++ b/uqcsbot/__init__.py
@@ -1,7 +1,8 @@
 import os
+import sys
 import importlib
 from uqcsbot.base import slack_events_adapter, bot, command_handler
-
+from uqcsbot.stub import ClientStub
 
 def main():
     dir_path = os.path.dirname(__file__)
@@ -12,7 +13,12 @@ def main():
         module = f'uqcsbot.scripts.{sub_file[:-3]}'
         importlib.import_module(module)
 
-    slack_events_adapter.start(port=5000)
+    if '--dev' in sys.argv:
+        stub = ClientStub(command_handler)
+        bot.client = stub
+        stub.adapter.prompt()
+    else:
+        slack_events_adapter.start(port=5000)
 
 if __name__ == "__main__":
     main()

--- a/uqcsbot/base.py
+++ b/uqcsbot/base.py
@@ -3,8 +3,8 @@ from slackclient import SlackClient
 from . import api, command_handler
 import os
 
-SLACK_VERIFICATION_TOKEN = os.environ["SLACK_VERIFICATION_TOKEN"]
-SLACK_BOT_TOKEN = os.environ["SLACK_BOT_TOKEN"]
+SLACK_VERIFICATION_TOKEN = os.environ.get("SLACK_VERIFICATION_TOKEN", "")
+SLACK_BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")
 
 slack_events_adapter = SlackEventAdapter(SLACK_VERIFICATION_TOKEN, "/uqcsbot/events")
 slack_client = SlackClient(SLACK_BOT_TOKEN)

--- a/uqcsbot/stub.py
+++ b/uqcsbot/stub.py
@@ -1,0 +1,24 @@
+from pyee import EventEmitter
+from uqcsbot.command_handler import CommandHandler
+
+class ClientStub(object):
+    def __init__(self, handler: CommandHandler):
+        self.adapter = EventAdapterStub()
+        self.adapter.on("message", handler.handle_command)
+
+    def api_call(self, call: str, channel: str, text: str):
+        if call == "chat.postMessage":
+            print(text)
+
+class EventAdapterStub(EventEmitter):
+    def prompt(self):
+        response = input("> ")
+        message = {
+            "event" : {
+                "text" : response,
+                "channel" : "general",
+                "subtype" : "user"
+            }
+        }
+        self.emit("message", message)
+        self.prompt()


### PR DESCRIPTION
Added a way to test locally using the `--dev` flag.

`python3 -m uqcsbot --dev`

Opens a local testing using stubs of the SlackClient and SlackEventAdapter classes.

Right now it only mimics receiving messages and the `chat.postMessage` event. It also considers every message to have been sent in "general".